### PR TITLE
Fix label color in dark mode

### DIFF
--- a/HideStuff/ApplicationsController/Sources/ApplicationsController/BundleStore.swift
+++ b/HideStuff/ApplicationsController/Sources/ApplicationsController/BundleStore.swift
@@ -3,12 +3,17 @@ import Foundation
 public class BundleStore: ObservableObject {
 
     public struct BundleFile: Identifiable, Equatable, Codable {
+        public let filePath: String
+        public let bundleIdentifier: String
+
+        public init(filePath: String, bundleIdentifier: String) {
+            self.filePath = filePath
+            self.bundleIdentifier = bundleIdentifier
+        }
+
         public var id: String {
             filePath
         }
-
-        public let filePath: String
-        let bundleIdentifier: String
     }
 
     @Published public private(set) var items: [BundleFile] {

--- a/HideStuff/ContentView.swift
+++ b/HideStuff/ContentView.swift
@@ -51,7 +51,7 @@ struct BundleListItem: View {
         HStack {
             Image(nsImage: NSWorkspace.shared.icon(forFile: bundle.filePath))
             Text(appName ?? bundle.filePath)
-                .foregroundColor(appBundle == nil ? .red : .black)
+                .foregroundColor(appBundle == nil ? Color.red : Color.primary)
                 .lineLimit(1)
             Spacer()
             Button("Remove") {
@@ -63,6 +63,12 @@ struct BundleListItem: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        Group {
+            BundleListItem(bundle: BundleStore.BundleFile(filePath: "/Applications/Safari.app", bundleIdentifier: "com.apple.Safari"))
+            BundleListItem(bundle: BundleStore.BundleFile(filePath: "/Applications/Safari.app", bundleIdentifier: "com.apple.Safari"))
+                .preferredColorScheme(.dark)
+                .background(Color.black)
+        }
+        .frame(width: 300.0)
     }
 }


### PR DESCRIPTION
Was using `.black` which doesn't switch to a light color in dark mode.
Also adds SwiftUI previews in both cases.

Fixes #1